### PR TITLE
Fix ros_web_video  HTTP header generation

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -573,7 +573,7 @@ void connection::handleRead(const boost::system::error_code& e,
           if (!is)
           {
             reply_ = reply::stock_reply(reply::not_found);
-            ROS_INFO("Http request from client %s: %s - file not found ", remote_ip.c_str(), request_.uri.c_str(), full_path.c_str());
+            ROS_INFO("Http request from client %s: %s - file not found", remote_ip.c_str(), full_path.c_str());
             return;
           }
 


### PR DESCRIPTION
This pull requests re-enables sending HTTP headers. In the past they had been broken because the asio buffer implementation was including the null terminator in it's buffers causing null bytes to be in the response headers, causing incorrect handling of the headers by the browser. This has the result of the browser correctly interpreting the access control header allowing for CORS.

This also enabled HTTP 1.1 transfer encoding

A small compiler warning was also fixed in one of the ROS_INFO statements.
